### PR TITLE
Update to most recent doomgeneric branch

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for entry in std::fs::read_dir(dg_src_dir)? {
         let entry = entry?;
         if let Some(filename) = entry.file_name().to_str() {
-            if filename.starts_with("doomgeneric") || filename == "i_main.c" {
+            if filename.starts_with("doomgeneric")
+                || filename.contains("_allegro")
+                || filename.contains("_sdl")
+                || filename == "i_main.c" {
                 continue;
             }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -17,8 +17,11 @@ pub trait DoomGeneric {
     fn set_window_title(&mut self, title: &str);
 }
 
+// TODO: Migrate to doomgeneric_Create
+
 extern "C" {
     fn D_DoomMain(); // doomgeneric.h
+    fn doomgeneric_Tick(); // doomgeneric.h
     fn M_FindResponseFile(); // used in main of i_main.c
     pub static mut myargc: raw::c_int;
     pub static mut myargv: *mut *mut raw::c_char;
@@ -95,5 +98,11 @@ pub fn init(doom_impl: impl DoomGeneric + 'static) {
         M_FindResponseFile();
         DG_Init();
         D_DoomMain();
+    }
+}
+
+pub fn tick() {
+    unsafe {
+        doomgeneric_Tick();
     }
 }


### PR DESCRIPTION
The crate currently fails to compile for me with Clang on macOS:

```
  cargo:warning=doomgeneric/doomgeneric/w_wad.c:364:5: error: call to undeclared function 'I_EndRead'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  cargo:warning=  364 |     I_EndRead ();
  cargo:warning=      |     ^
  cargo:warning=1 error generated.
```

This issue seems to have been fixed, however, a few new platform-specific source files were added, which we need to exclude.